### PR TITLE
Migrate from the localstack CLI to lstk

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,29 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: Setup tflocal
-        run: |
-          pip install terraform-local
 
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          pip install localstack awscli-local[ver1]
+          npm install -g @localstack/lstk
           docker pull localstack/localstack-pro:latest
           # Start LocalStack in the background
-          DEBUG=1 localstack start -d
-          # Wait 15 seconds for the LocalStack container to become ready before timing out
+          LOCALSTACK_DEBUG=1 lstk start --non-interactive
+          # Wait for the LocalStack container to become ready
           echo "Waiting for LocalStack startup..."
-          localstack wait -t 15
+          lstk status
           echo "Startup complete"
       
       - name: Run the application

--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,20 @@ usage:		## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
 install:	## Install dependencies
-	@which localstack || pip install localstack
-	@which awslocal || pip install awscli-local
-	@which tflocal || pip install terraform-local
+	@which lstk || npm install -g @localstack/lstk
 
 start:		## Start LocalStack
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start --non-interactive
 
 stop:		## Stop LocalStack
-	@localstack stop
+	@lstk stop
 
-ready:		## Wait until LocalStack is ready
-	@echo Waiting on the LocalStack container...
-	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+ready:		## Confirm LocalStack is ready (lstk start already waits, so this just reports status)
+	@lstk status
 
 logs:		## Save the logs in a separate file
-	@localstack logs > logs.txt
+	@lstk logs > logs.txt
 
 deploy:		## Deploy infrastructure using Terraform
 	terraform init

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [Terraform](https://docs.localstack.cloud/user-guide/integrations/terraform/) with the [`tflocal`](https://github.com/localstack/terraform-local) installed.
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/aws/getting-started/auth-token/) to activate LocalStack.
+- LocalStack with the [`lstk` CLI](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/).
+- [Terraform](https://docs.localstack.cloud/user-guide/integrations/terraform/) with the [`lstk tf` proxy](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/).
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/).
 
 Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 

--- a/run.sh
+++ b/run.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 # fail on errors
 set -eo pipefail
-# enable alias in script
-shopt -s expand_aliases
 
 if [ $# -eq 1 ] && [ $1 = "aws" ]; then
   echo "Deploying on AWS."
-  alias awslocal='aws'
-  alias tflocal='terraform'
+  tf="terraform"
 else
   echo "Deploying on LocalStack."
+  tf="lstk tf"
 fi
 
 # Start deployment
-tflocal init; tflocal plan; tflocal apply --auto-approve
-ingest_function_url=$(tflocal output --raw ingest_lambda_url)
-elasticsearch_endpoint=$(tflocal output --raw elasticsearch_endpoint)
+$tf init; $tf plan; $tf apply --auto-approve
+ingest_function_url=$($tf output --raw ingest_lambda_url)
+elasticsearch_endpoint=$($tf output --raw elasticsearch_endpoint)
 
 # download the dataset
 temp_dir=$(mktemp --directory)


### PR DESCRIPTION
## Summary
- Replace `localstack`/`tflocal` invocations with `lstk` across the Makefile, README, run.sh, and CI workflow.
- run.sh now picks `terraform` (real AWS) or `lstk tf` (LocalStack) via a variable instead of shell aliases.

## Testing
- CI workflow run on this branch.

Part of DEVX-1056